### PR TITLE
Implement count() method that provide spot2

### DIFF
--- a/src/Adapter/SpotAdapter.php
+++ b/src/Adapter/SpotAdapter.php
@@ -30,7 +30,7 @@ class SpotAdapter implements AdapterInterface
     {
         /* This works also with GROUP BY queries. */
         $query = clone $this->query;
-        return count($query->execute());
+        return $query->count();
     }
 
     public function slice(array $options)


### PR DESCRIPTION
I think that is better use the `count()` method that provide [spot2](https://github.com/spotorm/spot2/blob/master/lib/Query.php#L565-L571)